### PR TITLE
Add explanatory comments to symbol definitions in dictionary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,7 +10,7 @@
 2016, sabertooth-cat@users.sourceforge.net
 2014-2016, Iza Kusicielek <iza.kusicielek@gmail.com>
 2019, Tany Gómez <egomez@prompsit.com>
-2018, Alberto Navalon <alberto.navalonlillo@gmail.com>
+2018-2019, Alberto Navalón Lillo <albertonl.dev@gmail.com>
 2016, Marina Loffredo <loffredomarina@gmail.com>
 2016, Ульяна Сенцова <uliana.sentsova@gmail.com>
 2016, Frankie Robertson <frankie@robertson.name>


### PR DESCRIPTION
Submission of the GCI task: https://codein.withgoogle.com/tasks/5157779203948544/

I have commented the corresponding meaning right next to each symbol definition, as listed in the [wiki](http://wiki.apertium.org/wiki/List_of_symbols).

However, there are two symbols that are not documented and neither used in the monolingual dictionary:
- `v2`: this symbol appears in a commented `<pardef>`, but it is listed next to `vblex` and `cni`, so I cannot guess its meaning.
- `lquest`: due to its nature, I'm sure it refers to _left question mark_. However, it is not used anywhere, so I would like someone to correct me if I am wrong on that.

By now, the only not commented symbol is the `v2` one. Any comments on this would be really appreciated.